### PR TITLE
Fix deprecation warning for usage of fs#rmdir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "netlify-plugin-ttl-cache",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "name": "netlify-plugin-ttl-cache",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "jest": "^27.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { stat, unlink, rmdir } = require("fs").promises;
+const { stat, unlink, rm } = require("fs").promises;
 const { getDaysApart, getDirFilenames, addTrailingSlash } = require("./utils");
 
 const TMP_CACHE_DIR = ".netlify-plugin-ttl-cache";
@@ -38,7 +38,7 @@ const onPostBuild = async ({ utils, inputs }) => {
       addTrailingSlash(TMP_CACHE_DIR),
       addTrailingSlash(inputs.path),
     ]);
-    await rmdir(TMP_CACHE_DIR, { recursive: true });
+    await rm(TMP_CACHE_DIR, { recursive: true });
   }
 
   // Save new cache

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,14 +2,14 @@ jest.mock("fs", () => ({
   promises: {
     stat: jest.fn(),
     unlink: jest.fn(),
-    rmdir: jest.fn(),
+    rm: jest.fn(),
   },
 }));
 jest.mock("./utils", () => ({
   ...jest.requireActual("./utils"),
   getDirFilenames: jest.fn(),
 }));
-const { stat, unlink, rmdir } = require("fs").promises;
+const { stat, unlink, rm } = require("fs").promises;
 const { onPreBuild, onPostBuild } = require("./index");
 const { getDirFilenames } = require("./utils");
 
@@ -148,8 +148,8 @@ describe("on onPostBuild", () => {
 
     it("removes old cache directory", async () => {
       await onPostBuild({ inputs, utils });
-      expect(rmdir).toBeCalledTimes(1);
-      expect(rmdir.mock.calls[0]).toMatchInlineSnapshot(`
+      expect(rm).toBeCalledTimes(1);
+      expect(rm.mock.calls[0]).toMatchInlineSnapshot(`
 Array [
   ".netlify-plugin-ttl-cache",
   Object {


### PR DESCRIPTION
I noticed using this plugin that there is a [deprecation warning for the usage of fs#rmdir](https://nodejs.org/api/deprecations.html#DEP0147) so thought I would patch it just so something doesn't break in future 😄

Also noticed when running `npm i` after forking that the `package-lock.json` hadn't been updated since the last release so committing that too.